### PR TITLE
Add Gradle 9 and configuration cache support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,38 @@
 # Dependency Conflict Analyzer Gradle Plugin
 
-This plugin scans dependencies during Gradle sync and detects potential dependency conflicts.
-
-Gradle resolves dependency conflicts by selecting the highest version, which can silently introduce incompatibilities. This plugin helps detect such cases early and understand their root cause.
-
-It analyzes **major versions of artifacts** and highlights potentially incompatible upgrades selected by Gradle. The plugin also provides **dependency paths** for each conflicting version, helping you quickly identify which dependencies introduced the conflict and why it happened.
-
-Optionally, you can enable build failure on detected conflicts.
-
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/solneo/dependency-conflict-analyzer/blank.yml)](https://github.com/Solneo/dependency-conflict-analyzer/actions/workflows/blank.yml)
 [![GitHub](https://img.shields.io/github/license/solneo/dependency-conflict-analyzer)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Gradle Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/io.github.solneo.dependency-conflict-analyzer)](https://plugins.gradle.org/plugin/io.github.solneo.dependency-conflict-analyzer)
+
+A Gradle plugin that detects dependency version conflicts during sync and shows where each conflicting version came from.
+
+## Why this plugin
+
+Gradle already has tools for exploring dependency conflicts: the `dependencyInsight` task and the `failOnVersionConflict` resolution strategy. Both are reactive — you use them when you already know (or suspect) there's a problem, and you have to ask about a specific artifact.
+
+This plugin takes a different angle. It analyzes the resolved dependency graph on every sync and reports conflicts automatically, with full paths showing where each version came from. Conflicts surface on their own, without having to query the build.
+
+## What it does
+
+On every Gradle sync, the plugin traverses the resolved dependency graph and identifies artifacts that appear in more than one version. For each conflict it reports:
+
+- All versions present in the graph
+- The full dependency path for each version — through which modules and libraries it was pulled in
+- Which version Gradle ended up selecting
+
+By default, the plugin only prints the report. You can also configure it to fail the build when conflicts are detected.
+
+## Scope: major versions only
+
+The plugin reports conflicts between **different major versions** of an artifact (for example, `1.7.25` vs `2.0.17`). Minor and patch differences are not reported.
+
+This is by design. Under semantic versioning, major version bumps are where breaking API changes happen — these are the conflicts most likely to cause real runtime issues. Minor and patch differences are usually safe, and reporting them would generate noise without clear signal.
+
+## Compatibility
+
+- Gradle **8.3+** (tested with 8.3, 8.5, and 9.5)
+- Configuration cache: **supported**
+- Works with Java, Kotlin, and Android projects
 
 ## Usage
 
@@ -20,7 +42,7 @@ On your `build.gradle` add:
 
 ```groovy
 plugins {
-  id "io.github.solneo.dependency-conflict-analyzer" version "1.3.0"
+  id "io.github.solneo.dependency-conflict-analyzer" version "1.4.0"
 }
 ```
 
@@ -30,7 +52,7 @@ On your `build.gradle.kts` add:
 
 ```kotlin 
 plugins {
-    id("io.github.solneo.dependency-conflict-analyzer") version "1.3.0"
+    id("io.github.solneo.dependency-conflict-analyzer") version "1.4.0"
 }
 ```
 
@@ -73,16 +95,16 @@ dependencyConflictAnalyzer {
    excludeCheckingLibraries.set(listOf("com.example.code.group:artifact"))
 }
 ```
+
 ## Known Limitations
 
 ### Silently Upgraded Transitive Dependencies
 
-Gradle's resolution result only includes edges that survive the final resolution process.
-If a transitive dependency requests version `X`, but a higher version `Y` already exists
-in the graph, Gradle may omit the edge for `X` entirely — it never appears in the resolved graph.
+Gradle's `ResolutionResult` only contains edges that survived the final resolution.
+If a transitive dependency requests version `X`, but a higher version `Y` is already present
+in the graph via another path, Gradle may drop the edge for `X` entirely — it never appears in the resolved graph.
 
-As a result, the plugin cannot report conflicts involving versions that were silently
-upgraded by Gradle before the graph was finalized.
+As a result, the plugin cannot report conflicts involving versions that were dropped by Gradle before the graph was finalized.
 
 **Example:** if `library-a:1.0` transitively requires `slf4j:1.7.25`, but `slf4j:2.0.9`
 is already present via another path, Gradle may drop the `slf4j:1.7.25` edge completely.
@@ -99,9 +121,9 @@ The following are not included in conflict detection:
 - Dependencies resolved via BOM (`platform()` / `enforcedPlatform()`) where versions are aligned before graph construction
 - Dependencies suppressed via `resolutionStrategy.force()` or `resolutionStrategy.eachDependency {}`
 
+## Example output
 
 The plugin outputs a report to the console:
-
 
 <details>
 <summary>Text Report</summary>
@@ -120,3 +142,5 @@ Version conflict detected: org.slf4j:slf4j-api
 ```
 Note: dependencies are used only as an example
 </details>
+
+For more context, see the [article on Medium](https://medium.com/@chdanilr/gradle-plugin-to-catch-version-conflicts-and-their-sources-early-bcc75f509766).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("com.gradle.plugin-publish") version "2.1.1"
-    kotlin("jvm") version "1.5.31"
+    kotlin("jvm") version "1.9.20"
     `java-gradle-plugin`
     `kotlin-dsl`
 }
@@ -40,6 +40,7 @@ dependencies {
     testImplementation(kotlin("test"))
     testImplementation(gradleApi())
     testImplementation(gradleTestKit())
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.0")
 }
 
 tasks.test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.3.0
+version=1.4.0

--- a/src/main/kotlin/DependencyConflictAnalyzer.kt
+++ b/src/main/kotlin/DependencyConflictAnalyzer.kt
@@ -1,37 +1,45 @@
-import org.gradle.BuildAdapter
-import org.gradle.BuildResult
+import inspector.DependencyInspectorService
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.create
+import org.gradle.util.GradleVersion
+import reporting.FlowActionReportTrigger
+import reporting.LegacyReportTrigger
 
 class DependencyConflictAnalyzer : Plugin<Project> {
     override fun apply(project: Project) {
         val extension =
             project.extensions.create<DependencyConflictAnalyzerExtension>("dependencyConflictAnalyzer")
 
-        val dependencyInspector = DependencyInspector(extension)
+        val inspectorProvider = project.gradle.sharedServices.registerIfAbsent(
+            "dependencyInspector",
+            DependencyInspectorService::class.java,
+        ) {
+            parameters.failOnConflict.set(extension.failOnConflict)
+            parameters.excludeCheckingLibraries.set(extension.excludeCheckingLibraries)
+            parameters.excludeCheckingLibrariesGroup.set(extension.excludeCheckingLibrariesGroup)
+        }
 
         project.rootProject.allprojects {
             configurations
                 .matching {
-                    it.name.endsWith("CompileClasspath") &&
+                    it.name.endsWith("CompileClasspath", ignoreCase = true) &&
                             !it.name.contains("Test") &&
                             !it.name.contains("AndroidTest")
                 }
                 .all {
                     if (isCanBeResolved) {
-                        incoming.afterResolve(dependencyInspector::afterResolve)
-                        dependencyInspector.clearCache()
+                        val service = inspectorProvider.get()
+                        incoming.afterResolve(service::afterResolve)
                     }
                 }
         }
 
-        project.gradle.addBuildListener(object : BuildAdapter() {
-            override fun buildFinished(result: BuildResult) {
-                dependencyInspector.printConflicts()
-                dependencyInspector.clear()
-            }
-        })
+        if (GradleVersion.current() >= GradleVersion.version("8.1")) {
+            FlowActionReportTrigger.register(project, inspectorProvider)
+        } else {
+            LegacyReportTrigger.register(project, inspectorProvider)
+        }
     }
 }
 

--- a/src/main/kotlin/DependencyConflictAnalyzerExtension.kt
+++ b/src/main/kotlin/DependencyConflictAnalyzerExtension.kt
@@ -3,8 +3,6 @@ import org.gradle.api.provider.Property
 import strategy.ConflictStrategy
 import strategy.MajorVersionConflictStrategy
 
-@Suppress("LeakingThis")
-//check https://docs.gradle.org/current/userguide/custom_plugins.html#sec:getting_input_from_the_build
 abstract class DependencyConflictAnalyzerExtension {
     abstract val failOnConflict: Property<Boolean>
     val strategy: ConflictStrategy = MajorVersionConflictStrategy()

--- a/src/main/kotlin/inspector/DependencyBucket.kt
+++ b/src/main/kotlin/inspector/DependencyBucket.kt
@@ -1,3 +1,5 @@
+package inspector
+
 import org.gradle.api.artifacts.component.ComponentIdentifier
 
 data class DependencyBucket(

--- a/src/main/kotlin/inspector/DependencyInspectorService.kt
+++ b/src/main/kotlin/inspector/DependencyInspectorService.kt
@@ -1,19 +1,33 @@
+package inspector
+
 import java.util.concurrent.ConcurrentHashMap
 import org.gradle.api.GradleException
-import org.gradle.api.artifacts.DependencyResolutionListener
 import org.gradle.api.artifacts.ResolvableDependencies
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import strategy.ConflictStrategy
+import strategy.MajorVersionConflictStrategy
 
-class DependencyInspector(private val extension: DependencyConflictAnalyzerExtension) :
-    DependencyResolutionListener {
+abstract class DependencyInspectorService :
+    BuildService<DependencyInspectorService.Params> {
+
+    interface Params : BuildServiceParameters {
+        val failOnConflict: Property<Boolean>
+        val excludeCheckingLibraries: ListProperty<String>
+        val excludeCheckingLibrariesGroup: ListProperty<String>
+    }
+
+    private val strategy: ConflictStrategy = MajorVersionConflictStrategy()
 
     private val edgeRequestedVersion =
         ConcurrentHashMap<Pair<ComponentIdentifier, ComponentIdentifier>, String>()
-
     private val globalParents =
         ConcurrentHashMap<ComponentIdentifier, MutableSet<ComponentIdentifier>>()
     private val globalRequested =
@@ -21,14 +35,11 @@ class DependencyInspector(private val extension: DependencyConflictAnalyzerExten
     private val globalSelected = ConcurrentHashMap<ModuleKey, String>()
     private val pathCache = ConcurrentHashMap<ComponentIdentifier, List<DependencySource>>()
 
-    private val logger: Logger = LoggerFactory.getLogger(DependencyInspector::class.java)
-    override fun beforeResolve(dependencies: ResolvableDependencies) {
-        //don't need this method
-    }
+    private val logger: Logger = LoggerFactory.getLogger(DependencyInspectorService::class.java)
 
-    override fun afterResolve(dependencies: ResolvableDependencies) {
-        val excludeLibrariesGroupSet = extension.excludeCheckingLibrariesGroup.get().toSet()
-        val excludeLibrariesSet = extension.excludeCheckingLibraries.get().toSet()
+    fun afterResolve(dependencies: ResolvableDependencies) {
+        val excludeLibrariesGroupSet = parameters.excludeCheckingLibrariesGroup.get().toSet()
+        val excludeLibrariesSet = parameters.excludeCheckingLibraries.get().toSet()
         val rootId = dependencies.resolutionResult.root.id
 
         dependencies.resolutionResult.allDependencies.forEach { depResult ->
@@ -56,13 +67,9 @@ class DependencyInspector(private val extension: DependencyConflictAnalyzerExten
                 excludeLibrariesGroupSet.contains(group) ||
                 excludeLibrariesSet.contains(stringKey)
             ) return@forEach
-            val isDirect = fromId == rootId
 
-            val requester = Requester(
-                id = fromId,
-                root = rootId,
-                isDirect = isDirect
-            )
+            val isDirect = fromId == rootId
+            val requester = Requester(id = fromId, root = rootId, isDirect = isDirect)
 
             globalRequested
                 .getOrPut(key) { ConcurrentHashMap() }
@@ -129,8 +136,7 @@ class DependencyInspector(private val extension: DependencyConflictAnalyzerExten
         return result
     }
 
-    internal fun printConflicts() {
-
+    fun printConflicts() {
         val parents = globalParents.mapValues { it.value.toList() }
 
         globalRequested.forEach { (key, versionMap) ->
@@ -144,24 +150,24 @@ class DependencyInspector(private val extension: DependencyConflictAnalyzerExten
             }.toMutableMap()
 
             val bucket = DependencyBucket(key.group, key.name, requested, globalSelected[key] ?: "")
-            val conflict = extension.strategy.analyzeConflict(bucket)
+            val conflict = strategy.analyzeConflict(bucket)
             if (conflict.danger) {
                 logger.warn(conflict.msg)
-                if (extension.failOnConflict.get()) {
-                    throw GradleException("${conflict.msg}\n you can ignore this issue with parameter failOnConflict")
+                if (parameters.failOnConflict.get()) {
+                    throw GradleException(
+                        "${conflict.msg}\n you can ignore this issue with parameter failOnConflict"
+                    )
                 }
             }
         }
     }
 
-    internal fun clearCache() {
-        pathCache.clear()
-    }
-
-    internal fun clear() {
+    fun clear() {
+        edgeRequestedVersion.clear()
         globalParents.clear()
         globalRequested.clear()
         globalSelected.clear()
+        pathCache.clear()
     }
 
     companion object {
@@ -175,16 +181,4 @@ class DependencyInspector(private val extension: DependencyConflictAnalyzerExten
             "org.jetbrains.kotlin:kotlin-stdlib-common"
         )
     }
-
 }
-
-data class Requester(
-    val id: ComponentIdentifier,
-    val root: ComponentIdentifier,
-    val isDirect: Boolean
-)
-
-data class ModuleKey(
-    val group: String,
-    val name: String
-)

--- a/src/main/kotlin/inspector/ModuleKey.kt
+++ b/src/main/kotlin/inspector/ModuleKey.kt
@@ -1,0 +1,6 @@
+package inspector
+
+data class ModuleKey(
+    val group: String,
+    val name: String
+)

--- a/src/main/kotlin/inspector/Requester.kt
+++ b/src/main/kotlin/inspector/Requester.kt
@@ -1,0 +1,9 @@
+package inspector
+
+import org.gradle.api.artifacts.component.ComponentIdentifier
+
+data class Requester(
+    val id: ComponentIdentifier,
+    val root: ComponentIdentifier,
+    val isDirect: Boolean
+)

--- a/src/main/kotlin/reporting/FlowActionReportTrigger.kt
+++ b/src/main/kotlin/reporting/FlowActionReportTrigger.kt
@@ -1,0 +1,25 @@
+package reporting
+
+import inspector.DependencyInspectorService
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.flow.FlowActionSpec
+import org.gradle.api.flow.FlowScope
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.provider.Provider
+
+internal object FlowActionReportTrigger {
+    fun register(
+        project: Project,
+        inspectorProvider: Provider<DependencyInspectorService>,
+    ) {
+        val flowScope = (project as ProjectInternal).services.get(FlowScope::class.java)
+        val configure = object : Action<FlowActionSpec<PrintConflictsFlowAction.Params>> {
+            override fun execute(spec: FlowActionSpec<PrintConflictsFlowAction.Params>) {
+                spec.parameters.inspector.set(inspectorProvider)
+            }
+        }
+
+        flowScope.always(PrintConflictsFlowAction::class.java, configure)
+    }
+}

--- a/src/main/kotlin/reporting/LegacyReportTrigger.kt
+++ b/src/main/kotlin/reporting/LegacyReportTrigger.kt
@@ -1,0 +1,22 @@
+package reporting
+
+import inspector.DependencyInspectorService
+import org.gradle.BuildAdapter
+import org.gradle.BuildResult
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+
+internal object LegacyReportTrigger {
+    fun register(
+        project: Project,
+        inspectorProvider: Provider<DependencyInspectorService>,
+    ) {
+        project.gradle.addBuildListener(object : BuildAdapter() {
+            override fun buildFinished(result: BuildResult) {
+                val inspector = inspectorProvider.get()
+                inspector.printConflicts()
+                inspector.clear()
+            }
+        })
+    }
+}

--- a/src/main/kotlin/reporting/PrintConflictsFlowAction.kt
+++ b/src/main/kotlin/reporting/PrintConflictsFlowAction.kt
@@ -1,0 +1,20 @@
+package reporting
+
+import inspector.DependencyInspectorService
+import org.gradle.api.flow.FlowAction
+import org.gradle.api.flow.FlowParameters
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+
+abstract class PrintConflictsFlowAction : FlowAction<PrintConflictsFlowAction.Params> {
+    interface Params : FlowParameters {
+        @get:ServiceReference
+        val inspector: Property<DependencyInspectorService>
+    }
+
+    override fun execute(parameters: Params) {
+        val inspector = parameters.inspector.get()
+        inspector.printConflicts()
+        inspector.clear()
+    }
+}

--- a/src/main/kotlin/strategy/ConflictStrategy.kt
+++ b/src/main/kotlin/strategy/ConflictStrategy.kt
@@ -1,6 +1,6 @@
 package strategy
 
-import DependencyBucket
+import inspector.DependencyBucket
 
 interface ConflictStrategy {
     fun analyzeConflict(depResult: DependencyBucket): AnalyzedConflict

--- a/src/main/kotlin/strategy/MajorVersionConflictStrategy.kt
+++ b/src/main/kotlin/strategy/MajorVersionConflictStrategy.kt
@@ -1,6 +1,6 @@
 package strategy
 
-import DependencyBucket
+import inspector.DependencyBucket
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.slf4j.Logger

--- a/src/test/kotlin/DependencyConflictAnalyzerFunctionalTest.kt
+++ b/src/test/kotlin/DependencyConflictAnalyzerFunctionalTest.kt
@@ -1,0 +1,65 @@
+import java.io.File
+import kotlin.test.assertTrue
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class DependencyConflictAnalyzerFunctionalTest {
+
+    @TempDir
+    lateinit var projectDir: File
+
+    private fun setupProject() {
+        File(projectDir, "settings.gradle.kts").writeText(
+            """
+            rootProject.name = "test-project"
+            """.trimIndent()
+        )
+
+        File(projectDir, "build.gradle.kts").writeText(
+            """
+            plugins {
+                `java-library`
+                id("io.github.solneo.dependency-conflict-analyzer")
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation("com.google.code.gson:gson:1.7.2")
+                implementation("com.google.code.gson:gson:2.10.1")
+            }
+            """.trimIndent()
+        )
+
+        val srcDir = File(projectDir, "src/main/java")
+        srcDir.mkdirs()
+        File(srcDir, "Dummy.java").writeText("public class Dummy {}")
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["8.3", "8.5", "9.5.0"])
+    fun `detects major version conflict`(gradleVersion: String) {
+        setupProject()
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withGradleVersion(gradleVersion)
+            .withArguments("compileJava")
+            .forwardOutput()
+            .build()
+
+        println("=== OUTPUT ===")
+        println(result.output)
+        println("=== END ===")
+
+        assertTrue(
+            result.output.contains("Version conflict detected: com.google.code.gson:gson"),
+            "Expected conflict warning in output, got:\n${result.output}"
+        )
+    }
+}

--- a/src/test/kotlin/DependencyInspectorTest.kt
+++ b/src/test/kotlin/DependencyInspectorTest.kt
@@ -1,3 +1,4 @@
+import inspector.DependencyInspectorService
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.testfixtures.ProjectBuilder
@@ -6,18 +7,22 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class DependencyInspectorTest {
+class DependencyInspectorServiceTest {
 
-    private lateinit var inspector: DependencyInspector
+    private lateinit var inspector: DependencyInspectorService
 
     @BeforeEach
     fun setup() {
         val project = ProjectBuilder.builder().build()
-        val extension = project.extensions.create(
-            "dependencyConflictAnalyzer",
-            DependencyConflictAnalyzerExtension::class.java
-        )
-        inspector = DependencyInspector(extension)
+        val provider = project.gradle.sharedServices.registerIfAbsent(
+            "test-inspector",
+            DependencyInspectorService::class.java
+        ) {
+            parameters.failOnConflict.set(false)
+            parameters.excludeCheckingLibraries.set(emptyList())
+            parameters.excludeCheckingLibrariesGroup.set(emptyList())
+        }
+        inspector = provider.get()
     }
 
     private fun makeId(group: String, module: String, version: String): ComponentIdentifier =
@@ -54,7 +59,7 @@ class DependencyInspectorTest {
 
     @Test
     fun `findPathsToRoot respects MAX_DEPTH`() {
-        val ids = (0..DependencyInspector.MAX_DEPTH + 2).map { i ->
+        val ids = (0..DependencyInspectorService.MAX_DEPTH + 2).map { i ->
             makeId("org.test", "lib-$i", "1.0")
         }
         val parents = ids.zipWithNext()
@@ -70,12 +75,12 @@ class DependencyInspectorTest {
     fun `findPathsToRoot respects MAX_PATHS`() {
         val lib = makeId("org.slf4j", "slf4j-api", "2.0.9")
         val parents = mapOf<ComponentIdentifier, List<ComponentIdentifier>>(
-            lib to (0..DependencyInspector.MAX_PATHS + 5).map { i ->
+            lib to (0..DependencyInspectorService.MAX_PATHS + 5).map { i ->
                 makeId("project", "module-$i", "")
             }
         )
         val paths = inspector.findPathsToRoot(lib, parents)
-        assertTrue(paths.size <= DependencyInspector.MAX_PATHS)
+        assertTrue(paths.size <= DependencyInspectorService.MAX_PATHS)
     }
 
     @Test

--- a/src/test/kotlin/MajorVersionConflictStrategyTest.kt
+++ b/src/test/kotlin/MajorVersionConflictStrategyTest.kt
@@ -1,3 +1,6 @@
+import inspector.DependencyBucket
+import inspector.DependencyRequested
+import inspector.DependencySource
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.junit.jupiter.api.Assertions.*
@@ -20,7 +23,19 @@ class MajorVersionConflictStrategyTest {
         selected: String
     ): DependencyBucket {
         val requested = versions.associateWith { version ->
-            DependencyRequested(mutableSetOf(DependencySource(listOf(makeId("project", "app", "")))))
+            DependencyRequested(
+                mutableSetOf(
+                    DependencySource(
+                        listOf(
+                            makeId(
+                                "project",
+                                "app",
+                                ""
+                            )
+                        )
+                    )
+                )
+            )
         }.toMutableMap()
         return DependencyBucket(group, name, requested, selected)
     }


### PR DESCRIPTION
migrate to BuildService and FlowAction for configuration cache (#5)
fix configuration filter for non-Android projects
reorganize package structure
update tests and add functional tests
update readme